### PR TITLE
fixed a broken link on the pages success stories page

### DIFF
--- a/content/pages/success-stories.liquid
+++ b/content/pages/success-stories.liquid
@@ -25,7 +25,7 @@ hidetitle: true
         printable application in multiple languages for those states where electronic registration isn't an option.
         Vote.gov was ranked as the
         <a
-          href="{{ '/assets/documents/2017-benchmarking-us-government-websites.pdf' }}"
+          href="{{ 'https://cloud.gov/assets/documents/2017-benchmarking-us-government-websites.pdf' }}"
           >#1 federal website in 2017</a
         >
         by the Information Technology &amp; Innovation Foundation for meeting basic standards in security, speed, mobile


### PR DESCRIPTION
## Changes proposed in this pull request:
- fixed the broken "number 1 federal website in 2017" link


## security considerations
none, fixing existing links
