### PR TITLE
update logging reuqirements doc

### DIFF
--- a/content/docs/compliance/logging-requirements.md
+++ b/content/docs/compliance/logging-requirements.md
@@ -9,8 +9,7 @@ This document outlines how our platform enables cloud.gov customers to comply wi
 
 ### Basic Logging Categories
 
-- Cloud.gov currently retains logs in "active" storage (using ELK) for 6 months (to facilitate frequent use and ease of access), and 18 months in cold storage (using s3).
-- Cloud.gov will meet requirements by updating "active" storage to 12 months.
+- Cloud.gov currently retains logs in "active" storage (using OpenSearch) for 12 months (to facilitate frequent use and ease of access), and 18 months in cold storage (using S3)
 
 ### Minimum Logging Data
 

--- a/content/docs/deployment/logs.md
+++ b/content/docs/deployment/logs.md
@@ -47,7 +47,7 @@ If you receive `Error dialing trafficcontroller server`:
 
 To view and search your logs on the web, including historic log data, visit [https://logs.fr.cloud.gov/](https://logs.fr.cloud.gov/).
 
-Logs are currently retained for 365 days for live search (three years offline), and you will only see data for applications deployed within the [orgs](http://docs.cloudfoundry.org/concepts/roles.html#orgs) and [spaces](http://docs.cloudfoundry.org/concepts/roles.html#spaces) where you have access.
+Logs are currently retained for 365 days for live search (30 months offline), and you will only see data for applications deployed within the [orgs](http://docs.cloudfoundry.org/concepts/roles.html#orgs) and [spaces](http://docs.cloudfoundry.org/concepts/roles.html#spaces) where you have access.
 
 After logging in, you'll see the App Overview dashboard.
 


### PR DESCRIPTION
## Changes proposed in this pull request:
Update documentation about log retention to specify that logs are kept offline for 30 months, not 3 years. The 30 month cold storage retention period is specified by M-21-31, which says that logs must be kept in "hot storage" for 12 months, then for an additional 18 months in cold storage. So we keep logs in cold storage for 30 months total (12 + 18), not 3 years, which would be 36 months.
Update documentation about M-21-31 compliance to reflect updated 12 month log retention in OpenSearch

## security considerations
Updating our documentation about log retention to match requirements of M-21-31
