### PR TITLE
fixed oss policy links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,8 @@
-# Welcome!
+# Contributing
 
-We're so glad you're thinking about contributing to a [open source project of the U.S. government](https://code.gov/)! If you're unsure about anything, just ask -- or submit the issue or pull request anyway. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
+We're so glad you're thinking about contributing to an 18F open source project! If you're unsure or afraid of anything, just ask or submit the issue or pull request anyways. The worst that can happen is that you'll be politely asked to change something. We appreciate any sort of contribution, and don't want a wall of rules to get in the way of that.
 
-We encourage you to read this project's CONTRIBUTING policy (you are here), its [LICENSE](LICENSE.md), and its [README](README.md).
-
-## Policies
-
-We want to ensure a welcoming environment for all of our projects. Our staff follow the [TTS Code of Conduct](https://18f.gsa.gov/code-of-conduct/) and all contributors should do the same.
-
-We adhere to the [18F Open Source Policy](https://github.com/18f/open-source-policy). If you have any questions, just [shoot us an email](mailto:18f@gsa.gov).
-
-As part of a U.S. government agency, the General Services Administration (GSA)’s Technology Transformation Services (TTS) takes seriously our responsibility to protect the public’s information, including financial and personal information, from unwarranted disclosure. For more information about security and vulnerability disclosure for our projects, please read our [18F Vulnerability Disclosure Policy](https://18f.gsa.gov/vulnerability-disclosure-policy/).
+Before contributing, we encourage you to read our CONTRIBUTING policy (you are here), our LICENSE, and our README, all of which should be in this repository. If you have any questions, or want to read more about our underlying policies, you can consult the [GSA Open Source Policy](https://open.gsa.gov/oss/), or just shoot us an email/official government letterhead note to [support@cloud.gov](mailto:support@cloud.gov).
 
 ## Public domain
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -52,7 +52,7 @@
                   >
                 </li>
                 <li class="usa-footer__secondary-link">
-                  <a href="https://open.gsa.gov/oss/">Open source policy</a>
+                  <a href="https://open.gsa.gov/oss/" class="usa-link--external" target="_blank">Open source policy</a>
                 </li>
               </ul>
             </section>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -52,9 +52,7 @@
                   >
                 </li>
                 <li class="usa-footer__secondary-link">
-                  <a href="https://18f.gsa.gov/open-source-policy/" class="usa-link--external" target="_blank"
-                    >Open source policy</a
-                  >
+                  <a href="https://open.gsa.gov/oss/">Open source policy</a>
                 </li>
               </ul>
             </section>


### PR DESCRIPTION
## Changes proposed in this pull request:
Replace https://18f.gsa.gov/open-source-policy/ with https://open.gsa.gov/oss-policy/
Replace [18f@gsa.gov](mailto:18f@gsa.gov) with [support@cloud.gov](mailto:support@cloud.gov) in CONTRIBUTING.md

## security considerations
none, just fixing broken links
