### PR TITLE
Update link to Repositories in global footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,7 +25,7 @@
               <h4 class="usa-footer__primary-link">For developers</h4>
               <ul class="usa-list usa-list--unstyled">
                 <li class="usa-footer__secondary-link">
-                  <a href="{{ '/docs/ops/repos/#repositories' }}">Repositories</a>
+                  <a href="{{ 'https://github.com/cloud-gov/' }}">Repositories</a>
                 </li>
                 <li class="usa-footer__secondary-link">
                   <a href="{{ '/docs/pricing/free-limited-sandbox/' }}">Free developer sandbox</a>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updated link to "Repositories" in global footer to https://github.com/cloud-gov/

## security considerations
None, fixing links
