### PR TITLE
CNB update to core docs on site

### DIFF
--- a/content/docs/deployment/custom-buildpacks.md
+++ b/content/docs/deployment/custom-buildpacks.md
@@ -9,11 +9,17 @@ title: More languages (custom buildpacks)
 weight: 30
 ---
 
-Cloud Foundry (the underlying open source project behind cloud.gov) uses [buildpacks](/docs/getting-started/concepts/#buildpacks) to allow your applications to be deployed. cloud.gov [officially supports](/pricing/) a set of buildpacks, and it also allows you to provide your own.
+Cloud Foundry (the underlying open source project behind Cloud.gov) uses [buildpacks]({{site.baseurl }}/docs/getting-started/concepts/#buildpacks) to allow your applications to be deployed. Cloud.gov officially supports a set of "system buildpacks", but it also allows you to provide your own.
 
-Once you push your code using a custom buildpack, cloud.gov cannot update it for you. You are responsible for keeping it up to date. Please see [this description of responsibilities](/docs/technology/responsibilities/).
+Once you push your code using a custom buildpack, Cloud.gov cannot update it for you. You are responsible for keeping it up to date. Please see [this description of responsibilities]({{ site.baseurl }}/docs/technology/responsibilities/).
 
 ## Example custom buildpacks
+
+### Cloud Native Buildpacks
+
+The Cloud Native community has over the last few years developed a [Cloud Native Buildpack (CNB) ecosystem](https://buildpacks.io/). CNBs are the next stage in the evolution of buildpacks, and will eventually replace what are now (in 2025) called Classic Buildpacks. The CNBs provide better control, compliance and maintainability than either Classic Buildpacks or pre-built Docker images.
+
+A simple [Hello World example in NodeJS](https://github.com/cloud-gov/cf-hello-worlds/tree/main/nodejs) shows how to deploy an app to Cloud.gov using either the default Classic Buildpack, or a Cloud Native Buildpack via a `lifecycle` option.
 
 ### apt-buildpack
 

--- a/content/docs/getting-started/concepts.md
+++ b/content/docs/getting-started/concepts.md
@@ -94,3 +94,11 @@ buildpacks:
 If none of these strategies will help you deploy single-language applications, you can [explicitly specify a set of buildpacks to run in sequence](https://docs.cloudfoundry.org/buildpacks/use-multiple-buildpacks.html), one for each language.
 
 **Custom buildpacks:** If your application can't use a standard buildpack, you can use a [custom buildpack](/docs/deployment/custom-buildpacks). When you use a custom buildpack, you're responsible for keeping your buildpack up-to-date and patching vulnerabilities in it. See [this chart illustrating your responsibilities](/docs/technology/responsibilities) for more detail.
+
+**Cloud Native Buildpacks:** In early 2025, Cloud Foundry provided the option to deploy applications using [Cloud Native Buildpacks](https://buildpacks.io/), through the use of the `lifecycle` option in your manifest, or as a `cf push` option. You can see a basic example of this with the [NodeJS Hello World example](https://github.com/cloud-gov/cf-hello-worlds/tree/main/nodejs), where `manifest-cnb.yml` includes the following to specify the lifecycle and buildpack:
+
+```shell
+  lifecycle: cnb
+  buildpacks:
+  - docker://gcr.io/paketo-buildpacks/nodejs
+```

--- a/content/docs/technology/responsibilities.md
+++ b/content/docs/technology/responsibilities.md
@@ -26,6 +26,8 @@ App #2 uses a [custom buildpack]({{ "/docs/deployment/custom-buildpacks" }}), so
 - Continually updating your runtime and dependencies as new vulnerabilities are discovered and fixed.
 - Maintaining a best practice baseline configuration for your application framework/runtime that meets all applicable security standards.
 
+Examples of custom buildpacks includes [Cloud Native Buildpacks](https://buildpacks.io) as they are not yet (in early 2025) available within the Cloud.gov authorization boundary.
+
 App #3 is a Docker setup, where the customer is fully responsible for their Docker container and custom image. [Learn about this feature.]({{ "/docs/deployment/docker" }})
 
 Cloud.gov is always responsible for the following components at its platform level:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updated site to reflect CNB additions to 3 Docs pages (/deployment/custom-buildpacks.md, /getting-started/concepts.md, and /technology/responsibilities.md

## security considerations
Safe. Fleshes out our docs with references to open source material.