### PR TITLE
remove twitter username from meta tags

### DIFF
--- a/_data/site.yaml
+++ b/_data/site.yaml
@@ -7,7 +7,7 @@ baseurl: "" # the subpath of your site, e.g. /knowledge-base
 # url: "https://example.gov" # the base hostname & protocol for your site, e.g. http://example.com
 
 # Twitter handle. Only the handle, not the URL.
-twitter: clouddotgov
+# twitter: clouddotgov
 github_url: https://github.com/cloud-gov/cg-site
 support_email: mailto:support@cloud.gov?body=What+is+your+question%3F%0D%0A%0D%0APlease+provide+your+application+name+or+URL.+Do+not+include+any+sensitive+information+about+your+platform+in+this+email.
 inquiries_email: mailto:inquiries@cloud.gov?body=What%27s%20your%20name%3F%0A%0AWhat%20agency%20or%20office%20do%20you%20work%20for%3F%0A%0AWhat%27s%20your%20job%20title%20or%20role%3F%0A%0ATell%20us%20a%20little%20about%20your%20project%20or%20your%20questions%20about%20cloud.gov%3A%0A%0AIf%20you%27d%20like%20us%20to%20call%20you%2C%20what%27s%20your%20phone%20number%20and%20when%20might%20be%20a%20good%20time%3F%0A%0AHow%20did%20you%20first%20hear%20about%20cloud.gov%3F

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -40,8 +40,7 @@
   <meta name="description" content="{{summary}}">
   <meta property="og:description" content="{{summary}}">
 
-  <meta name="twitter:card" content="{{summary}}">
-  <meta name="twitter:site" content="@{{site.twitter}}">
+  <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="{{title}}">
   <meta name="twitter:description" content="{{summary}}">
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- changed cloudgov twitter handle to a comment just in case it might be used in the future
- reconfigured twitter card in meta


## security considerations
none, removed twitter handle from view
