### PR TITLE
Add custom prism theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,8 @@
         "anchor-js": "^5.0.0",
         "decap-cms": "^3.3.3",
         "eleventy-plugin-toc": "^1.1.5",
-        "katex": "^0.16.21",
         "mermaid": "^11.2.1",
-        "prettier": "^3.5.2",
-        "PrismJS": "git+https://github.com/PrismJS/prism-themes.git",
-        "undici": "^6.21.1"
+        "prettier": "^3.5.2"
       },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
@@ -10831,12 +10828,6 @@
       "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-2.0.0.tgz",
       "integrity": "sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==",
       "dev": true
-    },
-    "node_modules/PrismJS": {
-      "name": "prism-themes",
-      "version": "1.9.0",
-      "resolved": "git+ssh://git@github.com/PrismJS/prism-themes.git#447479fc7b2be2051fe27e561aceed7cc87a589f",
-      "license": "MIT"
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
@@ -22487,10 +22478,6 @@
       "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-2.0.0.tgz",
       "integrity": "sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==",
       "dev": true
-    },
-    "PrismJS": {
-      "version": "git+ssh://git@github.com/PrismJS/prism-themes.git#447479fc7b2be2051fe27e561aceed7cc87a589f",
-      "from": "PrismJS@git+https://github.com/PrismJS/prism-themes.git"
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "decap-cms": "^3.3.3",
     "eleventy-plugin-toc": "^1.1.5",
     "mermaid": "^11.2.1",
-    "prettier": "^3.5.2",
-    "PrismJS": "git+https://github.com/PrismJS/prism-themes.git"
+    "prettier": "^3.5.2"
   }
 }

--- a/styles/_prism.scss
+++ b/styles/_prism.scss
@@ -1,0 +1,143 @@
+/* Generated with http://k88hudson.github.io/syntax-highlighting-theme-generator/www */
+/* http://k88hudson.github.io/react-markdocs */
+/**
+ * @author k88hudson
+ *
+ * Based on prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+/*********************************************************
+* General
+*/
+pre[class*="language-"],
+code[class*="language-"] {
+  color: #171716;
+  font-size: 13px;
+  text-shadow: none;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.5;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+pre[class*="language-"]::selection,
+code[class*="language-"]::selection,
+pre[class*="language-"]::mozselection,
+code[class*="language-"]::mozselection {
+  text-shadow: none;
+  background: #b3d4fc;
+}
+@media print {
+  pre[class*="language-"],
+  code[class*="language-"] {
+    text-shadow: none;
+  }
+}
+pre[class*="language-"] {
+  padding: 1em;
+  margin: .5em 0;
+  overflow: auto;
+  background: #f5f5f0;
+}
+:not(pre) > code[class*="language-"] {
+  padding: .1em .3em;
+  border-radius: .3em;
+  color: #171716;
+  background: #f5f5f0;
+}
+/*********************************************************
+* Tokens
+*/
+.namespace {
+  opacity: .7;
+}
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #93a1a1;
+}
+.token.punctuation {
+  color: #999999;
+}
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #990055;
+}
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #669900;
+}
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+  color: #a67f59;
+  background: #ffffff;
+}
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+  color: #0077aa;
+}
+.token.function {
+  color: #dd4a68;
+}
+.token.regex,
+.token.important,
+.token.variable {
+  color: #ee9900;
+}
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+.token.italic {
+  font-style: italic;
+}
+.token.entity {
+  cursor: help;
+}
+/*********************************************************
+* Line highlighting
+*/
+pre[data-line] {
+  position: relative;
+}
+pre[class*="language-"] > code[class*="language-"] {
+  position: relative;
+  z-index: 1;
+}
+.line-highlight {
+  position: absolute;
+  left: 0;
+  right: 0;
+  padding: inherit 0;
+  margin-top: 1em;
+  background: #f7ebc6;
+  box-shadow: inset 5px 0 0 #f7d87c;
+  z-index: 0;
+  pointer-events: none;
+  line-height: inherit;
+  white-space: pre;
+}

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -202,9 +202,7 @@
 
 @forward "theme";
 @forward "mermaid";
+@forward "prism";
 @forward "helpers";
 @forward "footer";
-
 @forward "pages/index";
-
-@import "../node_modules/PrismJS/themes/prism-coldark-dark.css";


### PR DESCRIPTION
## Changes proposed in this pull request:
- Uses lighter theme for syntax highlighting 

Before:
<img width="637" alt="Screenshot 2025-04-11 at 12 18 56 PM" src="https://github.com/user-attachments/assets/68c659a0-9efd-444c-b582-a6083fd12042" />

After:
<img width="637" alt="Screenshot 2025-04-11 at 12 14 42 PM" src="https://github.com/user-attachments/assets/2d67a98a-9afb-49bb-a84a-8f6cb68e55dc" />

## security considerations
None