### PR TITLE
Add top-level quickstart to "your first deploy" page

### DIFF
--- a/content/docs/getting-started/your-first-deploy.md
+++ b/content/docs/getting-started/your-first-deploy.md
@@ -1,10 +1,29 @@
 ---
 showInSidenav: true
-title: Your first deploy
+title: "Quickstart: Deploy an app to Cloud.gov"
 weight: -30
 ---
 
 Practice deploying a simple "hello world" application using the cloud.gov command line interface (CLI).
+
+## Just the code
+
+```sh
+# Login to Cloud.gov
+cf login -a api.fr.cloud.gov --sso
+# Click the link, copy the code, paste it here, and hit enter.
+# Enter your org and space when prompted.
+# Next, clone the hello world repo:
+git clone https://github.com/cloud-gov/cf-hello-worlds.git
+# Change to the python hello world directory
+cd cf-hello-worlds/python-flask
+# Push the python hello world app
+cf push -f manifest.yml
+# View information about your new app, including the route
+cf app test-python-flask
+# Make a test request to the app using the route from the previous step
+curl https://your-app-route.app.cloud.gov
+```
 
 ## Get ready
 
@@ -14,7 +33,7 @@ Log in:
 
 1. Enter **`cf login -a api.fr.cloud.gov --sso`**
 1. It'll say `One Time Code ( Get one at `[`https://login.fr.cloud.gov/passcode`](https://login.fr.cloud.gov/passcode)` )` -- visit this login link in your browser.
-1. If you use a cloud.gov account, you may need to log in using your email address, password, and multi-factor authentication token. (EPA, FDIC, GSA, and NSF: use your agency button.)
+1. If you use a cloud.gov account, you may need to log in using your email address, password, and multi-factor authentication token. (If your agency's IDP is connected to Cloud.gov, use your agency button.)
 1. After you log in, the page will display your 10-character Temporary Authentication Code.
 1. Copy and paste that 10-character code into the command line (no typing indicators will show), and enter it.
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- A few customers have asked for a block of code they could just (basically) copy to get started with an app on Cloud.gov. "Quickstart" is the common terminology for the first tutorial which shows the basics of getting started with a new tool.

## security considerations
None.