### PR TITLE
Clarify yearly vs monthly credit values

### DIFF
--- a/content/pricing/index.liquid
+++ b/content/pricing/index.liquid
@@ -34,78 +34,101 @@ redirect_from:
       <thead>
         <tr>
           <th scope="col">Tier</th>
-          <th scope="col" class="text-right">Credits</th>
+          <th scope="col" class="text-right">Credits (Annual)</th>
+          <th scope="col" class="text-right">Credits (Monthly*)</th>
           <th scope="col" class="text-right">Annual Price</th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <th scope="row">Sandbox</th>
+          <td class="font-mono-md text-tabular text-right">N/A</td>
           <td class="font-mono-md text-tabular text-right">8</td>
           <td class="font-mono-md text-tabular text-right">$0</td>
         </tr>
         <tr>
           <th scope="row">Femto</th>
+          <td class="font-mono-md text-tabular text-right">600</td>
           <td class="font-mono-md text-tabular text-right">50</td>
           <td class="font-mono-md text-tabular text-right">$30,000</td>
         </tr>
         <tr>
           <th scope="row">Pico</th>
+          <td class="font-mono-md text-tabular text-right">1200</td>
           <td class="font-mono-md text-tabular text-right">100</td>
           <td class="font-mono-md text-tabular text-right">$60,000</td>
         </tr>
         <tr>
           <th scope="row">Nano</th>
+          <td class="font-mono-md text-tabular text-right">1800</td>
           <td class="font-mono-md text-tabular text-right">150</td>
           <td class="font-mono-md text-tabular text-right">$90,000</td>
         </tr>
         <tr>
           <th scope="row">Micro</th>
+          <td class="font-mono-md text-tabular text-right">3000</td>
           <td class="font-mono-md text-tabular text-right">250</td>
           <td class="font-mono-md text-tabular text-right">$150,000</td>
         </tr>
         <tr>
           <th scope="row">Milli</th>
+          <td class="font-mono-md text-tabular text-right">4200</td>
           <td class="font-mono-md text-tabular text-right">350</td>
           <td class="font-mono-md text-tabular text-right">$210,000</td>
         </tr>
         <tr>
           <th scope="row">Centi</th>
+          <td class="font-mono-md text-tabular text-right">6000</td>
           <td class="font-mono-md text-tabular text-right">500</td>
           <td class="font-mono-md text-tabular text-right">$300,000</td>
         </tr>
         <tr>
           <th scope="row">Deci</th>
+          <td class="font-mono-md text-tabular text-right">7800</td>
           <td class="font-mono-md text-tabular text-right">650</td>
           <td class="font-mono-md text-tabular text-right">$390,000</td>
         </tr>
         <tr>
           <th scope="row">Deka</th>
+          <td class="font-mono-md text-tabular text-right">9600</td>
           <td class="font-mono-md text-tabular text-right">800</td>
           <td class="font-mono-md text-tabular text-right">$456,000</td>
         </tr>
         <tr>
           <th scope="row">Hecto</th>
+          <td class="font-mono-md text-tabular text-right">12000</td>
           <td class="font-mono-md text-tabular text-right">1000</td>
           <td class="font-mono-md text-tabular text-right">$540,000</td>
         </tr>
         <tr>
           <th scope="row">Kilo</th>
+          <td class="font-mono-md text-tabular text-right">15000</td>
           <td class="font-mono-md text-tabular text-right">1250</td>
           <td class="font-mono-md text-tabular text-right">$637,500</td>
         </tr>
         <tr>
           <th scope="row">Mega</th>
+          <td class="font-mono-md text-tabular text-right">18000</td>
           <td class="font-mono-md text-tabular text-right">1500</td>
           <td class="font-mono-md text-tabular text-right">$720,000</td>
         </tr>
         <tr>
           <th scope="row">Giga</th>
+          <td class="font-mono-md text-tabular text-right">24000</td>
           <td class="font-mono-md text-tabular text-right">2000</td>
           <td class="font-mono-md text-tabular text-right">$936,000</td>
         </tr>
       </tbody>
     </table>  
+  </div>
+</section>
+<section class="usa-section">
+  <div class="grid-row grid-gap">
+    <div class="tablet:grid-col-7 usa-prose">
+      <p>
+        * All credits are available up-front when your IAA is executed. You can spend credits flexibly throughout the year if your workload is seasonal. Monthly credit amounts are provided for reference.
+      </p>
+    </div>
   </div>
 </section>
 <section class="usa-section">

--- a/content/pricing/index.liquid
+++ b/content/pricing/index.liquid
@@ -126,7 +126,7 @@ redirect_from:
   <div class="grid-row grid-gap">
     <div class="tablet:grid-col-7 usa-prose">
       <p>
-        * All credits are available up-front when your IAA is executed. You can spend credits flexibly throughout the year if your workload is seasonal. Monthly credit amounts are provided for reference.
+        * All credits are available up-front when your IAA is executed. You can spend credits flexibly throughout the year if your compute needs change over time. Monthly credit amounts are provided for reference.
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Changes proposed in this pull request:

- I kept the monthly values in the table because I think it's easier to see the deltas between tiers with the smaller numbers, but I'm open to removing them.
- Sandboxes are only available for 90 days, so I did not include a yearly credits total for those.

## security considerations
None.
