### PR TITLE
fix: take domain out of sprite path so CSR doesn't freak out

### DIFF
--- a/src/components/CostEstimator.astro
+++ b/src/components/CostEstimator.astro
@@ -76,7 +76,7 @@ const title = forSchema == "credits" ? "Cloud.gov Credit Estimator" : "Cloud.gov
       <div class="remove-container" role="gridcell">
         <button type="button" title="Remove" class="usa-button--unstyled remove-btn" aria-label="Remove row">
           <svg class="usa-icon usa-icon--size-4" role="img" aria-hidden="true">
-            <use href={`/assets/uswds/img/sprite.svg#delete`}></use>
+            <use href={`assets/uswds/img/sprite.svg#delete`}></use>
           </svg>
         </button>
       </div>

--- a/src/components/CostEstimator.astro
+++ b/src/components/CostEstimator.astro
@@ -76,7 +76,7 @@ const title = forSchema == "credits" ? "Cloud.gov Credit Estimator" : "Cloud.gov
       <div class="remove-container" role="gridcell">
         <button type="button" title="Remove" class="usa-button--unstyled remove-btn" aria-label="Remove row">
           <svg class="usa-icon usa-icon--size-4" role="img" aria-hidden="true">
-            <use href={`${Astro.site}assets/uswds/img/sprite.svg#delete`}></use>
+            <use href={`/assets/uswds/img/sprite.svg#delete`}></use>
           </svg>
         </button>
       </div>

--- a/src/components/Tiles.astro
+++ b/src/components/Tiles.astro
@@ -84,7 +84,7 @@ function formatTileWrapper(tileItem: Item) {
               ) : (
                 <span class="display-block">
                   <svg class="usa-icon usa-icon--size-6 accent" role="img" aria-hidden="true">
-                    <use href={`/assets/uswds/img/sprite.svg#${item.icon}`} />
+                    <use href={`assets/uswds/img/sprite.svg#${item.icon}`} />
                   </svg>
                 </span>
               )}

--- a/src/components/Tiles.astro
+++ b/src/components/Tiles.astro
@@ -84,7 +84,7 @@ function formatTileWrapper(tileItem: Item) {
               ) : (
                 <span class="display-block">
                   <svg class="usa-icon usa-icon--size-6 accent" role="img" aria-hidden="true">
-                    <use href={`${Astro.site}assets/uswds/img/sprite.svg#${item.icon}`} />
+                    <use href={`/assets/uswds/img/sprite.svg#${item.icon}`} />
                   </svg>
                 </span>
               )}

--- a/src/components/Topics.astro
+++ b/src/components/Topics.astro
@@ -33,7 +33,7 @@ const { items = [], color = "white", id, ...props } = Astro.props;
           {item.icon && (
             <div class="width-4 margin-right-2">
               <svg class="usa-icon usa-icon--size-4" role="img" aria-hidden="true">
-                <use href={`${Astro.site}assets/uswds/img/sprite.svg#${item.icon}`} />
+                <use href={`/assets/uswds/img/sprite.svg#${item.icon}`} />
               </svg>
             </div>
           )}
@@ -54,7 +54,7 @@ const { items = [], color = "white", id, ...props } = Astro.props;
                 <a class="usa-link" href={item.button.url}>
                   {item.button.label}
                   <svg class="usa-icon text-bottom width-2 height-205" aria-hidden="true" focusable="false" role="img">
-                    <use href={`${Astro.site}assets/uswds/img/sprite.svg#navigate_next`} />
+                    <use href={`/assets/uswds/img/sprite.svg#navigate_next`} />
                   </svg>
                 </a>
               </p>

--- a/src/components/Topics.astro
+++ b/src/components/Topics.astro
@@ -33,7 +33,7 @@ const { items = [], color = "white", id, ...props } = Astro.props;
           {item.icon && (
             <div class="width-4 margin-right-2">
               <svg class="usa-icon usa-icon--size-4" role="img" aria-hidden="true">
-                <use href={`/assets/uswds/img/sprite.svg#${item.icon}`} />
+                <use href={`assets/uswds/img/sprite.svg#${item.icon}`} />
               </svg>
             </div>
           )}
@@ -54,7 +54,7 @@ const { items = [], color = "white", id, ...props } = Astro.props;
                 <a class="usa-link" href={item.button.url}>
                   {item.button.label}
                   <svg class="usa-icon text-bottom width-2 height-205" aria-hidden="true" focusable="false" role="img">
-                    <use href={`/assets/uswds/img/sprite.svg#navigate_next`} />
+                    <use href={`assets/uswds/img/sprite.svg#navigate_next`} />
                   </svg>
                 </a>
               </p>


### PR DESCRIPTION
Fixes #181

I have no idea if this breaks something that was set up to use the domain intentionally…

## Changes proposed in this pull request:

Takes domain out of the sprite path so www.cloud.gov doesn't freak out about CSR on cloud.gov

## security considerations

None, just makes the path relate to whatever the current domain is.
