### PR TITLE
chore(security): harden Airtable contact embed on /contact

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -10,16 +10,68 @@ import sitewide from "../data/sitewide.yaml";
 
 <Layout title={content.title} description={content.description}>
   <Hero {...content.hero} />
-  <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"></script><iframe
+  <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"
+  ></script>
+  <iframe
+    title="Cloud.gov contact form (Airtable)"
     class="airtable-embed airtable-dynamic-height"
     src="https://airtable.com/embed/appbHJFEYs3H7fmA8/shrNrGC5KQnLgJqWc"
-    frameborder="0"
-    onmousewheel=""
+    loading="eager"
     width="100%"
     height="533"
-    style="background: url('./assets/img/loading.gif') no-repeat center 10% white; background-size: 10vw"></iframe>
+    referrerpolicy="origin"
+    sandbox="allow-forms allow-scripts"
+    allow="
+    geolocation 'none';
+    camera 'none';
+    microphone 'none';
+    clipboard-read 'none';
+    clipboard-write 'none';
+    payment 'none';
+    usb 'none';
+    bluetooth 'none';
+    xr-spatial-tracking 'none'
+  "
+    onload="this.style.backgroundImage='none'"
+    style="border:0;background:#fff url('/assets/img/loading.gif') no-repeat center 10%;background-size:10vw"
+  ></iframe>
   <Tiles {...sitewide.supportTiles} />
   <Subscribe {...sitewide.newsletter} />
 </Layout>
 
 <style></style>
+
+--- import Layout from "../layouts/Layout.astro"; import Hero from
+"../components/Hero.astro"; import Tiles from "../components/Tiles.astro";
+import Subscribe from "../components/Subscribe.astro"; import content from
+"../data/pages/contact.yaml"; import sitewide from "../data/sitewide.yaml"; ---
+
+<Layout title={content.title} description={content.description}>
+  <Hero {...content.headerSection} />
+  <script src="https://static.airtable.com/js/embed/embed_snippet_v1.js"
+  ></script><!-- Secure Airtable iframe (auto-loads, minimal) -->
+  <iframe
+    title="Cloud.gov contact form (Airtable)"
+    src="https://airtable.com/embed/appbHJFEYs3H7fmA8/shrNrGC5KQnLgJqWc"
+    loading="eager"
+    width="100%"
+    height="533"
+    referrerpolicy="origin"
+    sandbox="allow-forms allow-scripts"
+    allow="
+    geolocation 'none';
+    camera 'none';
+    microphone 'none';
+    clipboard-read 'none';
+    clipboard-write 'none';
+    payment 'none';
+    usb 'none';
+    bluetooth 'none';
+    xr-spatial-tracking 'none';
+    fullscreen 'none'
+  "
+    style="border:0"></iframe>
+
+  <Tiles {...sitewide.supportTiles} />
+  <Subscribe {...sitewide.newsletter} />
+</Layout>


### PR DESCRIPTION
## Changes proposed in this pull request:

- Replace raw Airtable iframe with a secured embed:
  - sandbox="allow-forms allow-scripts" (isolate third-party content)
  - referrerpolicy="origin" (Airtable sees only https://cloud.gov as referrer)
  - Deny powerful features via iframe allow (permissions policy)
  - Preserve loading.gif UX (cleared on onload)

## security considerations

- sandbox isolates the embed and enables only what a form needs (forms + scripts). 
- The iframe allow attribute further restricts powerful features (Permissions Policy) on top of any page-level policy. 
- referrerpolicy="origin" lets Airtable confirm traffic origin (e.g., https://cloud.gov) without leaking paths/params