### PR TITLE
fix CODEOWNERS syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
-# Per https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+# Per <https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax>
 
-# If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.
+# If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner
 
-- @cloud-gov/platform-ops @cloud-gov/pages-ops @cloud-gov/studio
+* @cloud-gov/platform-ops @cloud-gov/pages-ops @cloud-gov/studio


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix CODEOWNERS syntax so that reviews are automatically requested from specified teams

## security considerations

Having CODEOWNERS automatically tagged for review improves maintenance and makes sure that the right people are reviewing code
