### PR TITLE
Update broken links in sign-up.yaml

### DIFF
--- a/src/data/pages/sign-up.yaml
+++ b/src/data/pages/sign-up.yaml
@@ -24,7 +24,7 @@ kickTires:
     - heading: "**Experiment with the CLI**"
       text: "Dive right in with extensive self-documentation and community plugins"
     - heading: "**Deploy a demo app or two**"
-      text: "You can use [one of these sample apps]() or your own code."
+      text: "You can use [one of these sample apps](https://docs.cloud.gov/platform/getting-started/code-samples/) or your own code."
     - heading: "**Create some services**"
       text: "Create and bind a PostgreSQL or MySQL database instance for free"
     - heading: "**Review app logs**"
@@ -50,10 +50,10 @@ sandboxLimitations:
       text: "Experiment with databases, object storage, and more to try out the platform."
       icon: "update"
     - heading: "No production domains"
-      text: "Eager to launch? [Reach out to us]() before you go live."
+      text: "Eager to launch? [Reach out to us](mailto:inquiries@cloud.gov) before you go live."
       icon: "do_not_disturb"
     - heading: "Limited user roles"
-      text: "No org manager, but you can invite to your space. For team prototyping, consider [a handful of app credits]()."
+      text: "No org manager, but you can invite to your space. For team prototyping, consider [a handful of app credits](https://cloud.gov/pricing/)."
       icon: "group_add"
     - heading: "Agency IDP or Cloud.gov"
       text: "You can use our IDP as long as your agency hasn’t already integrated with Cloud.gov via SAML or OAuth."
@@ -72,7 +72,7 @@ servicesMedia:
   items:
     - heading: "Try it yourself"
       text: |
-        Deploy a [sample app](https://docs.cloud.gov/getting-started/code-samples) in minutes using the CLI and built-in buildpacks. Cloud.gov gives you a self-service, API-friendly platform with support for languages like Node.js, Python, Ruby, and Java. 
+        Deploy a [sample app](https://docs.cloud.gov/platform/getting-started/code-samples/) in minutes using the CLI and built-in buildpacks. Cloud.gov gives you a self-service, API-friendly platform with support for languages like Node.js, Python, Ruby, and Java. 
         
          Easily connect to services like PostgreSQL, MySQL, Redis (via ElastiCache), and S3-compatible storage through our service brokers — simple automations that let you provision and bind services with just a CLI command, no ticket required. 
       mediaComponent: "Illustration-Sequence-Diagram"


### PR DESCRIPTION
Closes #219 
Addresses broken links 

## Changes proposed in this pull request:
-Updated links pointing to sample apps to point to https://docs.cloud.gov/platform/getting-started/code-samples/
-Updated link to reach out to us to inquiries address 
-Updated "handful of credits" link to https://cloud.gov/pricing **This was a best guess - please confirm this is the desired link as part of review**

## security considerations
Should confirm that links are accurate and point to the correct websites owned by Cloud.gov
